### PR TITLE
Sidekiq queue configuration

### DIFF
--- a/app/jobs/hard_job.rb
+++ b/app/jobs/hard_job.rb
@@ -2,6 +2,7 @@
 class HardJob
   include Sidekiq::Worker
 
+  # https://github.com/sidekiq/sidekiq/wiki/Advanced-Options
   sidekiq_options queue: 'critical'
 
   def perform(complexity)

--- a/app/jobs/hard_job.rb
+++ b/app/jobs/hard_job.rb
@@ -2,6 +2,8 @@
 class HardJob
   include Sidekiq::Worker
 
+  sidekiq_options queue: 'critical'
+
   def perform(complexity)
     # Do something
     case complexity

--- a/config/sidekiq_config.yml
+++ b/config/sidekiq_config.yml
@@ -1,0 +1,3 @@
+# specify the custom queues needed here
+:queues:
+  - critical


### PR DESCRIPTION
https://github.com/sidekiq/sidekiq/wiki/Advanced-Options

### Notes
- By default the jobs will be queued to `queue` queue
- If we want a specific queue, mention the queue in job class and in config file
- Load the config file during sidekiq startup
> bundle exec sidekiq -C config/sidekiq_config.yml

### Redis
- A key will be created in redis `queue:critical` or `queue:<queue_name>`
- To get the list of jobs `LRANGE "queue:critical" 0 -1`