### PR TITLE
Rails helpers

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,5 @@
+module UsersHelper
+  def get_heading
+    'User console'
+  end
+end

--- a/app/views/users/_heading.html.erb
+++ b/app/views/users/_heading.html.erb
@@ -1,1 +1,1 @@
-<h1 style="text-align: center;">User console</h1>
+<h1 style="text-align: center;"><%= get_heading %></h1>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,7 @@ module EcommerceApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.action_controller.include_all_helpers = false
   end
 end


### PR DESCRIPTION
**Rails helpers**

- Rails framework will include all helpers by default for the views to access
- To restrict that we have to add the following line
`config.action_controller.include_all_helpers = false`

- After this, only the helpers which matches the controller name will be included (UsersController view will include UsersHelper)
- **note: _ApplicationHelpers will be globally accessible across all the views_**